### PR TITLE
Create chit creation screen

### DIFF
--- a/Chittr/App.js
+++ b/Chittr/App.js
@@ -8,6 +8,7 @@ import Feed from './components/Feed';
 import Chit from './components/Chit';
 import Login from './components/Login';
 import Register from './components/Register';
+import Compose from './components/Compose';
 
 function DetailsScreen({ navigation }) {
 	return (
@@ -93,6 +94,7 @@ class Chittr extends Component {
 					<Drawer.Screen name="Feed" component={StackNav} options={{ title: 'Latest Chits' }} />
 					<Drawer.Screen name="Login/Register" component={this.SignInRegister} />
 					<Drawer.Screen name="Register" component={Register} />
+					<Drawer.Screen name="New Chit" component={Compose} />
 					<Drawer.Screen name="Chit Test">
 						{props => <Chit {...props} item={item} />}
 					</Drawer.Screen>

--- a/Chittr/App.js
+++ b/Chittr/App.js
@@ -10,22 +10,6 @@ import Login from './components/Login';
 import Register from './components/Register';
 import Compose from './components/Compose';
 
-function DetailsScreen({ navigation }) {
-	return (
-		<View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
-			<Text>Details Screen</Text>
-			<Button
-				title="Go to Details... again"
-				onPress={() => navigation.push('Home')}
-			/>
-			<Button
-				title="Go back"
-				onPress={() => navigation.goBack()}
-			/>
-		</View>
-	);
-}
-
 function StackNav({ navigation }) {
 	return (
 		<Stack.Navigator initialRouteName="Feed">
@@ -93,12 +77,10 @@ class Chittr extends Component {
 				<Drawer.Navigator initialRouteName="Feed">
 					<Drawer.Screen name="Feed" component={StackNav} options={{ title: 'Latest Chits' }} />
 					<Drawer.Screen name="Login/Register" component={this.SignInRegister} />
-					<Drawer.Screen name="Register" component={Register} />
 					<Drawer.Screen name="New Chit" component={Compose} />
 					<Drawer.Screen name="Chit Test">
 						{props => <Chit {...props} item={item} />}
 					</Drawer.Screen>
-					<Drawer.Screen name="Details test" component={DetailsScreen} />
 				</Drawer.Navigator>
 			</NavigationContainer>
 		);

--- a/Chittr/components/Compose.js
+++ b/Chittr/components/Compose.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import { View, ActivityIndicator, TextInput, Button, Alert, ScrollView, Text, AsyncStorage } from 'react-native';
-import Chit from './Chit';
 
 class Compose extends Component {
     constructor (props) {
@@ -15,40 +14,51 @@ class Compose extends Component {
             location: '',
             user_token: '',
             user_id: '',
-            content: ''
+            content: '',
+            draft: ''
         };
     }
 
-    postChit(timestamp, content) {
+    async postChit(timestamp, content) {
         const data = JSON.stringify({
             timestamp: timestamp,
             chit_content: content,
         });
 
-        return fetch('http://10.0.2.2:3333/api/v0.0.5/chits', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                'X-Authorization': this.state.user_token
-            },
-            body: data
-        })
-            .then((response) => {
-                response.json()
-                this.props.navigation.goBack();
-            })
-            .catch((error) => {
-                console.log('>>> ERROR', error);
-                Alert.alert("Couldn't post chit, please try again");
+        try {
+            const response = await fetch('http://10.0.2.2:3333/api/v0.0.5/chits', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-Authorization': this.state.user_token
+                },
+                body: data
+            });
+            response.json();
+            this.props.navigation.goBack();
+        }
+        catch (error) {
+            console.log('>>> ERROR', error);
+            Alert.alert("Couldn't post chit, please try again");
+        }
+    }
 
-            })
+    setDraftValueLocally = (content) => {
+        AsyncStorage.setItem('@DRAFTS', content);
+        Alert.alert("Value stored successfully");
     }
 
     getValueLocally = () => {
         AsyncStorage.getItem('@LOGIN_TOKEN').then((value) => this.setState({ user_token: value }));
     }
 
+    getDraftValueLocally = () => {
+        AsyncStorage.getItem('@DRAFTS').then((value) => this.setState({ draft: value }));
+        console.log(">>>>>>>> DEBUG", this.state.draft);
+    }
+
     componentDidMount() {
+        this.getDraftValueLocally();
         this.getValueLocally();
     }
 
@@ -75,7 +85,11 @@ class Compose extends Component {
                     title='Chit'
                     onPress={() => { console.log('>>> TOKEN', this.state.user_token); this.postChit(Date.now(), this.state.content) }}
                 />
-                <Text>{this.state.loginMessage}</Text>
+                <Button
+                    title='Save as draft'
+                    onPress={() => { console.log('>>> TOKEN', this.state.user_token); this.setDraftValueLocally(this.state.content); console.log('>>> DRAFTS', this.state.drafts) }}
+                />
+                <Text>{this.state.draft}</Text>
             </View>
 
         )

--- a/Chittr/components/Compose.js
+++ b/Chittr/components/Compose.js
@@ -1,0 +1,85 @@
+import React, { Component } from 'react';
+import { View, ActivityIndicator, TextInput, Button, Alert, ScrollView, Text, AsyncStorage } from 'react-native';
+import Chit from './Chit';
+
+class Compose extends Component {
+    constructor (props) {
+        super(props);
+
+        this.state = {
+            chittrResponse: [],
+            chit_id: '',
+            timestamp: '',
+            chit_content: '',
+            user: [],
+            location: '',
+            user_token: '',
+            user_id: '',
+            content: ''
+        };
+    }
+
+    postChit(timestamp, content) {
+        const data = JSON.stringify({
+            timestamp: timestamp,
+            chit_content: content,
+        });
+
+        return fetch('http://10.0.2.2:3333/api/v0.0.5/chits', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-Authorization': this.state.user_token
+            },
+            body: data
+        })
+            .then((response) => {
+                response.json()
+                this.props.navigation.goBack();
+            })
+            .catch((error) => {
+                console.log('>>> ERROR', error);
+                Alert.alert("Couldn't post chit, please try again");
+
+            })
+    }
+
+    getValueLocally = () => {
+        AsyncStorage.getItem('@LOGIN_TOKEN').then((value) => this.setState({ user_token: value }));
+    }
+
+    componentDidMount() {
+        this.getValueLocally();
+    }
+
+    render() {
+        if (this.state.isLoading) {
+            return (
+                <View>
+                    <ActivityIndicator />
+                </View>
+            )
+        }
+
+        return (
+            <View>
+                <TextInput
+                    autoFocus={true}
+                    maxLength={141}
+                    multiline={true}
+                    onChangeText={(content) => { this.setState({ content }) }}
+                    placeholder='Enter Text'
+                    style={{ width: 300 }}>
+                </TextInput>
+                <Button
+                    title='Chit'
+                    onPress={() => { console.log('>>> TOKEN', this.state.user_token); this.postChit(Date.now(), this.state.content) }}
+                />
+                <Text>{this.state.loginMessage}</Text>
+            </View>
+
+        )
+    }
+}
+
+export default Compose;

--- a/Chittr/components/Feed.js
+++ b/Chittr/components/Feed.js
@@ -142,7 +142,7 @@ class Feed extends Component {
         return (
             <View>
                 <Button
-                    title='Registerr'
+                    title='Register'
                     onPress={() => { this.postUserRegister() }}
                 />
                 <Button


### PR DESCRIPTION
# Description
Added a drawer item that allows the creation of a new chit. This can be posted right away and re-navigates to the home page, or it can be saved as a draft. Draft functionality isn't currently implemented, but the content is stored in `AsyncStorage` and displayed below for now.